### PR TITLE
Add AWS Terraform setup for Nifty data fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# AWS Nifty Data Fetch Infrastructure
+
+This repository contains Terraform code and a simple AWS Lambda function to
+fetch Nifty index data at a 15 minute interval each day. The Lambda function
+retrieves data from Yahoo Finance and stores the result in an S3 bucket.
+
+## Components
+
+- **Lambda Function** (`infra/lambda_function.py`)
+  - Downloads the latest one day 15‑minute data for the Nifty index.
+  - Saves the JSON response to an S3 bucket specified by the environment
+    variable `BUCKET_NAME`.
+- **Terraform** (`infra/main.tf`)
+  - Creates an S3 bucket for the data.
+  - Deploys the Lambda function.
+  - Schedules the function to run daily using CloudWatch Events.
+
+## Deployment
+
+1. Install [Terraform](https://www.terraform.io/).
+2. Configure your AWS credentials in the environment.
+3. Initialize and apply the Terraform configuration:
+
+   ```bash
+   cd infra
+   terraform init
+   terraform apply
+   ```
+
+This will provision the S3 bucket, Lambda function, IAM role, and CloudWatch
+Events rule. The function will execute once per day and store the data in the
+bucket under `nifty_data/YYYY-MM-DD.json`.
+
+## Notes
+
+- Yahoo Finance data may be subject to change or rate limits. Use this example
+  as a starting point and adapt it as necessary for your use case.
+- Ensure that the IAM role created by Terraform has only the minimal
+  permissions required for security best practices.

--- a/infra/lambda_function.py
+++ b/infra/lambda_function.py
@@ -1,0 +1,16 @@
+import json
+import boto3
+import datetime
+import urllib.request
+import os
+
+def lambda_handler(event, context):
+    bucket = os.environ['BUCKET_NAME']
+    date_str = datetime.datetime.utcnow().strftime('%Y-%m-%d')
+    url = 'https://query1.finance.yahoo.com/v8/finance/chart/%5ENSEI?range=1d&interval=15m'
+    with urllib.request.urlopen(url) as response:
+        data = json.load(response)
+    s3_key = f'nifty_data/{date_str}.json'
+    s3 = boto3.client('s3')
+    s3.put_object(Bucket=bucket, Key=s3_key, Body=json.dumps(data).encode('utf-8'))
+    return {'status': 'success', 'key': s3_key}

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,110 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+resource "aws_s3_bucket" "data" {
+  bucket = var.bucket_name
+}
+
+resource "aws_iam_role" "lambda" {
+  name = "nifty_lambda_role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Principal = {
+        Service = "lambda.amazonaws.com"
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "lambda" {
+  name = "nifty_lambda_policy"
+  role = aws_iam_role.lambda.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Effect   = "Allow"
+        Resource = "arn:aws:logs:*:*:*"
+      },
+      {
+        Action   = ["s3:PutObject"],
+        Effect   = "Allow",
+        Resource = "${aws_s3_bucket.data.arn}/*"
+      }
+    ]
+  })
+}
+
+data "archive_file" "lambda_zip" {
+  type        = "zip"
+  source_file = "${path.module}/lambda_function.py"
+  output_path = "${path.module}/lambda_function.zip"
+}
+
+resource "aws_lambda_function" "fetch_nifty" {
+  function_name = "fetch_nifty_data"
+  role          = aws_iam_role.lambda.arn
+  handler       = "lambda_function.lambda_handler"
+  runtime       = "python3.10"
+  filename      = data.archive_file.lambda_zip.output_path
+  source_code_hash = data.archive_file.lambda_zip.output_base64sha256
+
+  environment {
+    variables = {
+      BUCKET_NAME = aws_s3_bucket.data.bucket
+    }
+  }
+}
+
+resource "aws_cloudwatch_event_rule" "daily" {
+  name                = "daily_nifty_fetch"
+  schedule_expression = "cron(0 0 * * ? *)"
+}
+
+resource "aws_cloudwatch_event_target" "lambda_target" {
+  rule      = aws_cloudwatch_event_rule.daily.name
+  target_id = "nifty_lambda"
+  arn       = aws_lambda_function.fetch_nifty.arn
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.fetch_nifty.function_name
+  principal     = "events.amazonaws.com"
+  source_arn    = aws_cloudwatch_event_rule.daily.arn
+}
+
+variable "bucket_name" {
+  description = "Name of the S3 bucket to store data"
+  type        = string
+  default     = "nifty-data-bucket"
+}
+
+variable "aws_region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+output "bucket_name" {
+  value = aws_s3_bucket.data.bucket
+}


### PR DESCRIPTION
## Summary
- add a Lambda function to retrieve Nifty 15-minute data and write to S3
- create Terraform code to provision a Lambda, IAM role, S3 bucket and scheduler
- document deployment steps in README

## Testing
- `terraform fmt -check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f2b1661108323b880d8ebabfbe512